### PR TITLE
fix: examples do not import jsx elements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ bun install react-daisyui-timetools
 ### DatePicker
 
 ```tsx
-import DatePicker from "react-daisyui-timetools"
+import { DatePicker } from "react-daisyui-timetools"
 ```
 
 A stylish, easy-to-use date picker.

--- a/docs/docs/datepicker.mdx
+++ b/docs/docs/datepicker.mdx
@@ -17,7 +17,7 @@ Built with accessibility in mind, and leveraging DasiyUI and Tailwind CSS, this 
 ## Usage
 
 ```tsx
-import DatePicker from "react-daisyui-timetools"
+import { DatePicker } from "react-daisyui-timetools"
 
 <DatePicker value="2025-01-01 12:00" onChange={() => {}} weekStart="sunday" />
 ```
@@ -32,7 +32,7 @@ use the `pickYear` prop to show a year picker.
 range of years is set by `minDate` and `maxDate`.
 
 ```tsx
-import DatePicker from "react-daisyui-timetools"
+import { DatePicker } from "react-daisyui-timetools"
 
 <DatePicker value="2025-01-01 12:00" onChange={() => {}} weekStart="sunday" pickYear />
 ```


### PR DESCRIPTION
Examples do not import react elements, but the whole library.
This PR fixes examples.